### PR TITLE
Fix if order.

### DIFF
--- a/aldryn_style/templates/aldryn_style/plugin.html
+++ b/aldryn_style/templates/aldryn_style/plugin.html
@@ -1,6 +1,6 @@
 {% load cms_tags %}
 {% spaceless %}
-<{{ instance.tag_type }}{% if instance.id_name %} id="{{ instance.id_name }}"{% endif %}{% if instance.class_name %} class="{{ instance.class_name }}{% if instance.additional_class_names %} {{ instance.get_additional_class_names }}{% endif %}"{% endif %}>
+<{{ instance.tag_type }}{% if instance.id_name %} id="{{ instance.id_name }}"{% endif %} class="{% if instance.class_name %}{{ instance.class_name }}{% endif %}{% if instance.additional_class_names %} {{ instance.get_additional_class_names }}{% endif %}">
 {% for plugin in instance.child_plugin_instances %}
 	{% render_plugin plugin %}
 {% endfor %}


### PR DESCRIPTION
Closes #16 
This pull request fix the if statement order in plugin template. `class_name` is not required but in plugin template it acts as required.