### PR TITLE
Minor template fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ build
 env*
 dist
 aldryn_style.egg-info
+.idea

--- a/aldryn_style/templates/aldryn_style/plugin.html
+++ b/aldryn_style/templates/aldryn_style/plugin.html
@@ -1,6 +1,6 @@
 {% load cms_tags %}
 {% spaceless %}
-<{{ instance.tag_type }}{% if instance.id_name %} id="{{ instance.id_name }}"{% endif %} class="{% if instance.class_name %}{{ instance.class_name }}{% endif %}{% if instance.additional_class_names %} {{ instance.get_additional_class_names }}{% endif %}">
+<{{ instance.tag_type }}{% if instance.id_name %} id="{{ instance.id_name }}"{% endif %} class="{% if instance.class_name %}{{ instance.class_name }}{% endif %}{% if instance.class_name and instance.additional_class_names %} {% endif %}{% if instance.additional_class_names %}{{ instance.get_additional_class_names }}{% endif %}">
 {% for plugin in instance.child_plugin_instances %}
 	{% render_plugin plugin %}
 {% endfor %}


### PR DESCRIPTION
Essentially, we only emit a space-separator if there are both class_name and additional_class_names, otherwise, no space is all.