### PR TITLE
Add more tag types to select from

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,12 @@
 Changelog
 =========
 
+x.x.x (xxxx-xx-xx)
+------------------
+
+* Add more tag types to select from
+
+
 1.0.0 (2015-11-09)
 ------------------
 
@@ -9,8 +15,8 @@ Changelog
 0.3.0 (2015-10-15)
 ------------------
 
-* fixes additional classes
-* cms 3.1 migration compatibility fix
+* Fix additional classes
+* CMS 3.1 migration compatibility fix
 
 
 0.2.1 (2015-06-18)

--- a/aldryn_style/models.py
+++ b/aldryn_style/models.py
@@ -28,13 +28,23 @@ class Style(CMSPlugin):
     DIV_TAG = 'div'
     ARTICLE_TAG = 'article'
     SECTION_TAG = 'section'
-    INLINE_TAG = 'span'
+    SPAN_TAG = 'span'
+    P_TAG = 'p'
+    H1_TAG = 'h1'
+    H2_TAG = 'h2'
+    H3_TAG = 'h3'
+    H4_TAG = 'h4'
 
     HTML_TAG_TYPES = (
         (DIV_TAG, _('div')),
         (ARTICLE_TAG, _('article')),
         (SECTION_TAG, _('section')),
-        (INLINE_TAG, _('inline')),
+        (SPAN_TAG, _('span')),
+        (P_TAG, _('paragraph')),
+        (H1_TAG, _('heading 1')),
+        (H2_TAG, _('heading 2')),
+        (H3_TAG, _('heading 3')),
+        (H4_TAG, _('heading 4')),
     )
 
     label = models.CharField(_('label'), max_length=128, default="", blank=True,


### PR DESCRIPTION
This allows a broader set of tags to select from in the plugin settings
form.

While this hardcodes most frequently used tags, it would be nice to
allow to put arbitrary tag types. This will require some refactoring of
the validation logic and Aldryn configuration form.