### PR TITLE
Fix for empty setting

### DIFF
--- a/aldryn_style/cms_plugins.py
+++ b/aldryn_style/cms_plugins.py
@@ -1,7 +1,12 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import unicode_literals
+
+from django.utils.translation import ugettext_lazy as _
+
 from cms.plugin_pool import plugin_pool
 from cms.plugin_base import CMSPluginBase
-from django.utils.translation import ugettext_lazy as _
-from cms.models import CMSPlugin
+
 from aldryn_style.models import Style
 
 

--- a/aldryn_style/models.py
+++ b/aldryn_style/models.py
@@ -44,7 +44,7 @@ def get_html_tag_types():
     # Could be that it was initially empty, or, none of the supplied entries
     # looked right, in either of these cases, use the default set as defined
     # in version 1.0.1.
-    if tag_types is None:
+    if not tag_types:
         tag_types = [
             'div', 'article', 'section', 'span', 'p', 'h1', 'h2', 'h3', 'h4',
         ]


### PR DESCRIPTION
This prevents the additional classes field from appearing as a free-form text input when an empty list is set for ALDRYN_STYLE_ALLOWED_TAGS.