### PR TITLE
add header/footer to taglist

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,7 @@ Changelog
 1.1.1 (UNRELEASED)
 ------------------
 * Add missing h-tags to ``tag_types``
+* Add missing header and footer to ``tag_types``
 
 1.1.0 (2015-12-16)
 ------------------

--- a/README.rst
+++ b/README.rst
@@ -39,7 +39,9 @@ empty list, then it will default to the following list for backwards
 compatibility with previous versions::
 
     ALDRYN_STYLE_ALLOWED_TAGS = [
-        'div', 'article', 'section', 'span', 'p', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6',
+        'div', 'article', 'section', 'p', 'span',
+        'h1', 'h2', 'h3', 'h4', 'h5', 'h6',
+        'header', 'footer',
     ]
 
 NOTICE::

--- a/aldryn_style/models.py
+++ b/aldryn_style/models.py
@@ -48,6 +48,7 @@ def get_html_tag_types():
         tag_types = [
             'div', 'article', 'section', 'p', 'span',
             'h1', 'h2', 'h3', 'h4', 'h5', 'h6',
+            'header', 'footer',
         ]
 
     return tuple([(tag, tag) for tag in tag_types])


### PR DESCRIPTION
This adds header and footer to the taglist after adding the missing htags in https://github.com/aldryn/aldryn-style/pull/26